### PR TITLE
meson.build: change define for C++ too

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -77,7 +77,7 @@ private_cfg.set('HAVE_STRUCT_STAT_ST_ATIMESPEC',
 add_project_arguments('-D_REENTRANT', '-DHAVE_LIBFUSE_PRIVATE_CONFIG_H', '-Wno-sign-compare',
                       '-Wstrict-prototypes', '-Wmissing-declarations', '-Wwrite-strings',
                       '-fno-strict-aliasing', language: 'c')
-add_project_arguments('-D_REENTRANT', '-DHAVE_CONFIG_H', '-D_GNU_SOURCE',
+add_project_arguments('-D_REENTRANT', '-DHAVE_LIBFUSE_PRIVATE_CONFIG_H', '-D_GNU_SOURCE',
                      '-Wno-sign-compare', '-Wmissing-declarations',
                      '-Wwrite-strings', '-fno-strict-aliasing', language: 'cpp')
 


### PR DESCRIPTION
Commit d7560cc has split defines into private and public, and passed -DHAVE_LIBFUSE-PRIVATE_CONFIG_H to all C programs. But the arguments of C++ programs have not been changed. This leads to a test failure as reported in issue #734. Pass -DHAVE_LIBFUSE-PRIVATE_CONFIG_H to C++ programs too.

Fixes: #734